### PR TITLE
Made it work without being admin

### DIFF
--- a/WinLess/Settings.cs
+++ b/WinLess/Settings.cs
@@ -57,7 +57,7 @@ namespace WinLess
         }
 
         public void SaveSettings(){
-            string dataDir = string.Format("{0}\\data", Application.CommonAppDataPath);
+            string dataDir = string.Format("{0}\\data", Application.UserAppDataPath);
             string settingsFilePath = string.Format("{0}\\settings.xml", dataDir);
             
             try {     
@@ -82,7 +82,7 @@ namespace WinLess
 
         public static Settings LoadSettings()
         {
-            string path = string.Format("{0}\\data\\settings.xml", Application.CommonAppDataPath);
+            string path = string.Format("{0}\\data\\settings.xml", Application.UserAppDataPath);
             if (System.IO.File.Exists(path))
             {
                 try


### PR DESCRIPTION
Changed so the settings is being save to the Users AppData instaed of ProgramData on a win8 machine, don't know if it worked on win7, but it should store the settings the right place now
