### PR TITLE
Added an opt-in solution for issue #27 and made issue #9 significantly easier.

### DIFF
--- a/WinLess/Forms/mainForm.Designer.cs
+++ b/WinLess/Forms/mainForm.Designer.cs
@@ -71,6 +71,7 @@
             this.notifyIconMenuOpen = new System.Windows.Forms.ToolStripMenuItem();
             this.notifyIconMenuExit = new System.Windows.Forms.ToolStripMenuItem();
             this.outputFolderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
+			this.advancedOutputFolderBrowserDialog = new System.Windows.Forms.OpenFileDialog();
             this.logoPictureBox = new System.Windows.Forms.PictureBox();
             this.compileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.directoryBindingSource)).BeginInit();
@@ -558,6 +559,7 @@
         private System.Windows.Forms.ToolStripMenuItem fileOpenFolderToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openFiletoolStripMenuItem;
         private System.Windows.Forms.FolderBrowserDialog outputFolderBrowserDialog;
+		private System.Windows.Forms.OpenFileDialog advancedOutputFolderBrowserDialog;
         private System.Windows.Forms.PictureBox logoPictureBox;
         private System.Windows.Forms.DataGridViewTextBoxColumn timeDataGridViewTextBoxColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn fileDataGridViewTextBoxColumn;

--- a/WinLess/Forms/mainForm.cs
+++ b/WinLess/Forms/mainForm.cs
@@ -299,13 +299,29 @@ namespace WinLess
             DataGridViewCell cell = filesDataGridView.SelectedCells[0];
             Models.File file = (Models.File)cell.OwningRow.DataBoundItem;
             FileInfo fileInfo = new FileInfo(file.OutputPath);
-            outputFolderBrowserDialog.SelectedPath = fileInfo.DirectoryName;
-            if (outputFolderBrowserDialog.ShowDialog() == DialogResult.OK)
-            {
-                file.OutputPath = string.Format("{0}\\{1}", outputFolderBrowserDialog.SelectedPath, fileInfo.Name);
-                filesDataGridView_DataChanged();
-                Program.Settings.SaveSettings();
-            }
+
+			if (!Program.Settings.UseAdvancedOutputFileSelector)
+			{
+				outputFolderBrowserDialog.SelectedPath = fileInfo.DirectoryName;
+				if (outputFolderBrowserDialog.ShowDialog() == DialogResult.OK)
+				{
+					file.OutputPath = string.Format("{0}\\{1}", outputFolderBrowserDialog.SelectedPath, fileInfo.Name);
+					filesDataGridView_DataChanged();
+					Program.Settings.SaveSettings();
+				}
+			}
+			else
+			{
+				advancedOutputFolderBrowserDialog.InitialDirectory = fileInfo.DirectoryName;
+				advancedOutputFolderBrowserDialog.FileName = fileInfo.Name;
+				if (advancedOutputFolderBrowserDialog.ShowDialog() == DialogResult.OK)
+				{
+					file.OutputPath = advancedOutputFolderBrowserDialog.FileName;
+				}
+			}
+
+			filesDataGridView_DataChanged();
+			Program.Settings.SaveSettings();
         }
 
         #endregion

--- a/WinLess/Forms/settingsForm.Designer.cs
+++ b/WinLess/Forms/settingsForm.Designer.cs
@@ -28,130 +28,142 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(settingsForm));
-            this.cancelButton = new System.Windows.Forms.Button();
-            this.okButton = new System.Windows.Forms.Button();
-            this.generalGroupBox = new System.Windows.Forms.GroupBox();
-            this.startMinimizedCheckBox = new System.Windows.Forms.CheckBox();
-            this.startWithWindowsCheckBox = new System.Windows.Forms.CheckBox();
-            this.compilingGroupBox = new System.Windows.Forms.GroupBox();
-            this.compileOnSaveCheckBox = new System.Windows.Forms.CheckBox();
-            this.defaultMinifyCheckBox = new System.Windows.Forms.CheckBox();
-            this.showSuccessMessagesCheckbox = new System.Windows.Forms.CheckBox();
-            this.generalGroupBox.SuspendLayout();
-            this.compilingGroupBox.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Location = new System.Drawing.Point(197, 197);
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(75, 23);
-            this.cancelButton.TabIndex = 0;
-            this.cancelButton.Text = "Cancel";
-            this.cancelButton.UseVisualStyleBackColor = true;
-            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
-            // 
-            // okButton
-            // 
-            this.okButton.Location = new System.Drawing.Point(116, 197);
-            this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(75, 23);
-            this.okButton.TabIndex = 1;
-            this.okButton.Text = "Ok";
-            this.okButton.UseVisualStyleBackColor = true;
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
-            // 
-            // generalGroupBox
-            // 
-            this.generalGroupBox.Controls.Add(this.startMinimizedCheckBox);
-            this.generalGroupBox.Controls.Add(this.startWithWindowsCheckBox);
-            this.generalGroupBox.Location = new System.Drawing.Point(13, 13);
-            this.generalGroupBox.Name = "generalGroupBox";
-            this.generalGroupBox.Size = new System.Drawing.Size(259, 72);
-            this.generalGroupBox.TabIndex = 2;
-            this.generalGroupBox.TabStop = false;
-            this.generalGroupBox.Text = "General";
-            // 
-            // startMinimizedCheckBox
-            // 
-            this.startMinimizedCheckBox.AutoSize = true;
-            this.startMinimizedCheckBox.Location = new System.Drawing.Point(7, 44);
-            this.startMinimizedCheckBox.Name = "startMinimizedCheckBox";
-            this.startMinimizedCheckBox.Size = new System.Drawing.Size(96, 17);
-            this.startMinimizedCheckBox.TabIndex = 1;
-            this.startMinimizedCheckBox.Text = "Start minimized";
-            this.startMinimizedCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // startWithWindowsCheckBox
-            // 
-            this.startWithWindowsCheckBox.AutoSize = true;
-            this.startWithWindowsCheckBox.Location = new System.Drawing.Point(7, 20);
-            this.startWithWindowsCheckBox.Name = "startWithWindowsCheckBox";
-            this.startWithWindowsCheckBox.Size = new System.Drawing.Size(117, 17);
-            this.startWithWindowsCheckBox.TabIndex = 0;
-            this.startWithWindowsCheckBox.Text = "Start with Windows";
-            this.startWithWindowsCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // compilingGroupBox
-            // 
-            this.compilingGroupBox.Controls.Add(this.showSuccessMessagesCheckbox);
-            this.compilingGroupBox.Controls.Add(this.compileOnSaveCheckBox);
-            this.compilingGroupBox.Controls.Add(this.defaultMinifyCheckBox);
-            this.compilingGroupBox.Location = new System.Drawing.Point(13, 91);
-            this.compilingGroupBox.Name = "compilingGroupBox";
-            this.compilingGroupBox.Size = new System.Drawing.Size(259, 100);
-            this.compilingGroupBox.TabIndex = 3;
-            this.compilingGroupBox.TabStop = false;
-            this.compilingGroupBox.Text = "Compiling";
-            // 
-            // compileOnSaveCheckBox
-            // 
-            this.compileOnSaveCheckBox.AutoSize = true;
-            this.compileOnSaveCheckBox.Location = new System.Drawing.Point(7, 44);
-            this.compileOnSaveCheckBox.Name = "compileOnSaveCheckBox";
-            this.compileOnSaveCheckBox.Size = new System.Drawing.Size(209, 17);
-            this.compileOnSaveCheckBox.TabIndex = 1;
-            this.compileOnSaveCheckBox.Text = "Automatically compile files when saved";
-            this.compileOnSaveCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // defaultMinifyCheckBox
-            // 
-            this.defaultMinifyCheckBox.AutoSize = true;
-            this.defaultMinifyCheckBox.Location = new System.Drawing.Point(7, 21);
-            this.defaultMinifyCheckBox.Name = "defaultMinifyCheckBox";
-            this.defaultMinifyCheckBox.Size = new System.Drawing.Size(102, 17);
-            this.defaultMinifyCheckBox.TabIndex = 0;
-            this.defaultMinifyCheckBox.Text = "Minify by default";
-            this.defaultMinifyCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // showSuccessMessagesCheckbox
-            // 
-            this.showSuccessMessagesCheckbox.AutoSize = true;
-            this.showSuccessMessagesCheckbox.Location = new System.Drawing.Point(7, 68);
-            this.showSuccessMessagesCheckbox.Name = "showSuccessMessagesCheckbox";
-            this.showSuccessMessagesCheckbox.Size = new System.Drawing.Size(200, 17);
-            this.showSuccessMessagesCheckbox.TabIndex = 2;
-            this.showSuccessMessagesCheckbox.Text = "Show message on succesful compile";
-            this.showSuccessMessagesCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // settingsForm
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(289, 232);
-            this.Controls.Add(this.compilingGroupBox);
-            this.Controls.Add(this.generalGroupBox);
-            this.Controls.Add(this.okButton);
-            this.Controls.Add(this.cancelButton);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Name = "settingsForm";
-            this.Text = "Settings";
-            this.generalGroupBox.ResumeLayout(false);
-            this.generalGroupBox.PerformLayout();
-            this.compilingGroupBox.ResumeLayout(false);
-            this.compilingGroupBox.PerformLayout();
-            this.ResumeLayout(false);
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(settingsForm));
+			this.cancelButton = new System.Windows.Forms.Button();
+			this.okButton = new System.Windows.Forms.Button();
+			this.generalGroupBox = new System.Windows.Forms.GroupBox();
+			this.startMinimizedCheckBox = new System.Windows.Forms.CheckBox();
+			this.startWithWindowsCheckBox = new System.Windows.Forms.CheckBox();
+			this.compilingGroupBox = new System.Windows.Forms.GroupBox();
+			this.showSuccessMessagesCheckbox = new System.Windows.Forms.CheckBox();
+			this.compileOnSaveCheckBox = new System.Windows.Forms.CheckBox();
+			this.defaultMinifyCheckBox = new System.Windows.Forms.CheckBox();
+			this.useAdvancedOutputFileSelector = new System.Windows.Forms.CheckBox();
+			this.generalGroupBox.SuspendLayout();
+			this.compilingGroupBox.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// cancelButton
+			// 
+			this.cancelButton.Location = new System.Drawing.Point(202, 226);
+			this.cancelButton.Name = "cancelButton";
+			this.cancelButton.Size = new System.Drawing.Size(75, 23);
+			this.cancelButton.TabIndex = 0;
+			this.cancelButton.Text = "Cancel";
+			this.cancelButton.UseVisualStyleBackColor = true;
+			this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+			// 
+			// okButton
+			// 
+			this.okButton.Location = new System.Drawing.Point(121, 226);
+			this.okButton.Name = "okButton";
+			this.okButton.Size = new System.Drawing.Size(75, 23);
+			this.okButton.TabIndex = 1;
+			this.okButton.Text = "OK";
+			this.okButton.UseVisualStyleBackColor = true;
+			this.okButton.Click += new System.EventHandler(this.okButton_Click);
+			// 
+			// generalGroupBox
+			// 
+			this.generalGroupBox.Controls.Add(this.startMinimizedCheckBox);
+			this.generalGroupBox.Controls.Add(this.startWithWindowsCheckBox);
+			this.generalGroupBox.Location = new System.Drawing.Point(13, 13);
+			this.generalGroupBox.Name = "generalGroupBox";
+			this.generalGroupBox.Size = new System.Drawing.Size(259, 72);
+			this.generalGroupBox.TabIndex = 2;
+			this.generalGroupBox.TabStop = false;
+			this.generalGroupBox.Text = "General";
+			// 
+			// startMinimizedCheckBox
+			// 
+			this.startMinimizedCheckBox.AutoSize = true;
+			this.startMinimizedCheckBox.Location = new System.Drawing.Point(7, 44);
+			this.startMinimizedCheckBox.Name = "startMinimizedCheckBox";
+			this.startMinimizedCheckBox.Size = new System.Drawing.Size(96, 17);
+			this.startMinimizedCheckBox.TabIndex = 1;
+			this.startMinimizedCheckBox.Text = "Start minimized";
+			this.startMinimizedCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// startWithWindowsCheckBox
+			// 
+			this.startWithWindowsCheckBox.AutoSize = true;
+			this.startWithWindowsCheckBox.Location = new System.Drawing.Point(7, 20);
+			this.startWithWindowsCheckBox.Name = "startWithWindowsCheckBox";
+			this.startWithWindowsCheckBox.Size = new System.Drawing.Size(117, 17);
+			this.startWithWindowsCheckBox.TabIndex = 0;
+			this.startWithWindowsCheckBox.Text = "Start with Windows";
+			this.startWithWindowsCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// compilingGroupBox
+			// 
+			this.compilingGroupBox.Controls.Add(this.useAdvancedOutputFileSelector);
+			this.compilingGroupBox.Controls.Add(this.showSuccessMessagesCheckbox);
+			this.compilingGroupBox.Controls.Add(this.compileOnSaveCheckBox);
+			this.compilingGroupBox.Controls.Add(this.defaultMinifyCheckBox);
+			this.compilingGroupBox.Location = new System.Drawing.Point(13, 91);
+			this.compilingGroupBox.Name = "compilingGroupBox";
+			this.compilingGroupBox.Size = new System.Drawing.Size(259, 120);
+			this.compilingGroupBox.TabIndex = 3;
+			this.compilingGroupBox.TabStop = false;
+			this.compilingGroupBox.Text = "Compiling";
+			// 
+			// showSuccessMessagesCheckbox
+			// 
+			this.showSuccessMessagesCheckbox.AutoSize = true;
+			this.showSuccessMessagesCheckbox.Location = new System.Drawing.Point(7, 68);
+			this.showSuccessMessagesCheckbox.Name = "showSuccessMessagesCheckbox";
+			this.showSuccessMessagesCheckbox.Size = new System.Drawing.Size(200, 17);
+			this.showSuccessMessagesCheckbox.TabIndex = 2;
+			this.showSuccessMessagesCheckbox.Text = "Show message on succesful compile";
+			this.showSuccessMessagesCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// compileOnSaveCheckBox
+			// 
+			this.compileOnSaveCheckBox.AutoSize = true;
+			this.compileOnSaveCheckBox.Location = new System.Drawing.Point(7, 44);
+			this.compileOnSaveCheckBox.Name = "compileOnSaveCheckBox";
+			this.compileOnSaveCheckBox.Size = new System.Drawing.Size(209, 17);
+			this.compileOnSaveCheckBox.TabIndex = 1;
+			this.compileOnSaveCheckBox.Text = "Automatically compile files when saved";
+			this.compileOnSaveCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// defaultMinifyCheckBox
+			// 
+			this.defaultMinifyCheckBox.AutoSize = true;
+			this.defaultMinifyCheckBox.Location = new System.Drawing.Point(7, 21);
+			this.defaultMinifyCheckBox.Name = "defaultMinifyCheckBox";
+			this.defaultMinifyCheckBox.Size = new System.Drawing.Size(102, 17);
+			this.defaultMinifyCheckBox.TabIndex = 0;
+			this.defaultMinifyCheckBox.Text = "Minify by default";
+			this.defaultMinifyCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// useAdvancedOutputFileSelector
+			// 
+			this.useAdvancedOutputFileSelector.AutoSize = true;
+			this.useAdvancedOutputFileSelector.Location = new System.Drawing.Point(7, 91);
+			this.useAdvancedOutputFileSelector.Name = "useAdvancedOutputFileSelector";
+			this.useAdvancedOutputFileSelector.Size = new System.Drawing.Size(185, 17);
+			this.useAdvancedOutputFileSelector.TabIndex = 0;
+			this.useAdvancedOutputFileSelector.Text = "Use advanced output file selector";
+			this.useAdvancedOutputFileSelector.UseVisualStyleBackColor = true;
+			// 
+			// settingsForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(289, 260);
+			this.Controls.Add(this.compilingGroupBox);
+			this.Controls.Add(this.generalGroupBox);
+			this.Controls.Add(this.okButton);
+			this.Controls.Add(this.cancelButton);
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.Name = "settingsForm";
+			this.Text = "Settings";
+			this.generalGroupBox.ResumeLayout(false);
+			this.generalGroupBox.PerformLayout();
+			this.compilingGroupBox.ResumeLayout(false);
+			this.compilingGroupBox.PerformLayout();
+			this.ResumeLayout(false);
 
         }
 
@@ -165,6 +177,7 @@
         private System.Windows.Forms.GroupBox compilingGroupBox;
         private System.Windows.Forms.CheckBox defaultMinifyCheckBox;
         private System.Windows.Forms.CheckBox compileOnSaveCheckBox;
-        private System.Windows.Forms.CheckBox showSuccessMessagesCheckbox;
+		private System.Windows.Forms.CheckBox showSuccessMessagesCheckbox;
+		private System.Windows.Forms.CheckBox useAdvancedOutputFileSelector;
     }
 }

--- a/WinLess/Forms/settingsForm.cs
+++ b/WinLess/Forms/settingsForm.cs
@@ -23,6 +23,7 @@ namespace WinLess
             defaultMinifyCheckBox.Checked = Program.Settings.DefaultMinify;
             compileOnSaveCheckBox.Checked = Program.Settings.CompileOnSave;
             showSuccessMessagesCheckbox.Checked = Program.Settings.ShowSuccessMessages;
+			useAdvancedOutputFileSelector.Checked = Program.Settings.UseAdvancedOutputFileSelector;
         }
 
         private void saveSettings()
@@ -32,6 +33,7 @@ namespace WinLess
             Program.Settings.DefaultMinify = defaultMinifyCheckBox.Checked;
             Program.Settings.CompileOnSave = compileOnSaveCheckBox.Checked;
             Program.Settings.ShowSuccessMessages = showSuccessMessagesCheckbox.Checked;
+			Program.Settings.UseAdvancedOutputFileSelector = useAdvancedOutputFileSelector.Checked;
             Program.Settings.SaveSettings();
         }
 

--- a/WinLess/Settings.cs
+++ b/WinLess/Settings.cs
@@ -19,6 +19,7 @@ namespace WinLess
             ShowSuccessMessages = false;
             StartWithWindows = true;
             StartMinified = false;
+	        UseAdvancedOutputFileSelector = false;
             ApplyStartWithWindows();
         }
 
@@ -27,6 +28,7 @@ namespace WinLess
         public bool CompileOnSave { get; set; }
         public bool ShowSuccessMessages { get; set; }
         public bool StartMinified { get; set; }
+		public bool UseAdvancedOutputFileSelector { get; set; }
 
         private bool startWithWindows;
         public bool StartWithWindows


### PR DESCRIPTION
This changeset solves two problems by adding a new setting that allows
users to opt-in to use the "advanced" output file selector.  This new
selector is simply an OpenFileDialog instead of a terrible
FolderBrowserDialog.   The two problems that this new dialog solves are:
(1) A custom file name can be added as requested by issue #27, and (2)
It is much easier to edit the output folder with the OpenFileDialog
because you can type/paste a file path (which helps a bit with issue
#9).

![NewStuff](https://f.cloud.github.com/assets/1881968/20804/4b99ad08-496a-11e2-9350-c99e4f63b1ee.png)
