### PR TITLE
Added support to add debug-info in css. 

### DIFF
--- a/WinLess/Forms/aboutForm.Designer.cs
+++ b/WinLess/Forms/aboutForm.Designer.cs
@@ -30,6 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(aboutForm));
             this.versionGroupBox = new System.Windows.Forms.GroupBox();
+            this.updatingLabel = new System.Windows.Forms.Label();
             this.checkingForUpdatesLabel = new System.Windows.Forms.Label();
             this.lessjsVersionLabel = new System.Windows.Forms.Label();
             this.lessjsLabel = new System.Windows.Forms.Label();
@@ -40,7 +41,6 @@
             this.authorNameLabel = new System.Windows.Forms.Label();
             this.graphicalDesignLabel = new System.Windows.Forms.Label();
             this.authorLabel = new System.Windows.Forms.Label();
-            this.updatingLabel = new System.Windows.Forms.Label();
             this.versionGroupBox.SuspendLayout();
             this.creditsGroupBox.SuspendLayout();
             this.SuspendLayout();
@@ -59,6 +59,16 @@
             this.versionGroupBox.TabIndex = 1;
             this.versionGroupBox.TabStop = false;
             this.versionGroupBox.Text = "Version info";
+            // 
+            // updatingLabel
+            // 
+            this.updatingLabel.AutoSize = true;
+            this.updatingLabel.Location = new System.Drawing.Point(165, 37);
+            this.updatingLabel.Name = "updatingLabel";
+            this.updatingLabel.Size = new System.Drawing.Size(59, 13);
+            this.updatingLabel.TabIndex = 5;
+            this.updatingLabel.Text = "Updating...";
+            this.updatingLabel.Visible = false;
             // 
             // checkingForUpdatesLabel
             // 
@@ -153,16 +163,6 @@
             this.authorLabel.Size = new System.Drawing.Size(41, 13);
             this.authorLabel.TabIndex = 0;
             this.authorLabel.Text = "Author:";
-            // 
-            // updatingLabel
-            // 
-            this.updatingLabel.AutoSize = true;
-            this.updatingLabel.Location = new System.Drawing.Point(165, 37);
-            this.updatingLabel.Name = "updatingLabel";
-            this.updatingLabel.Size = new System.Drawing.Size(59, 13);
-            this.updatingLabel.TabIndex = 5;
-            this.updatingLabel.Text = "Updating...";
-            this.updatingLabel.Visible = false;
             // 
             // aboutForm
             // 

--- a/WinLess/Forms/aboutForm.cs
+++ b/WinLess/Forms/aboutForm.cs
@@ -54,6 +54,8 @@ namespace WinLess
                     MessageBox.Show(string.Format("Succesfully updated less.js to version {0}", newVersion), "LESS compiler update");
                 }
             }            
-        }        
+        }
+
+            
     }
 }

--- a/WinLess/Forms/mainForm.Designer.cs
+++ b/WinLess/Forms/mainForm.Designer.cs
@@ -272,6 +272,7 @@
             this.filesDataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
             this.filesDataGridView.Size = new System.Drawing.Size(581, 303);
             this.filesDataGridView.TabIndex = 5;
+            this.filesDataGridView.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.filesDataGridView_CellContentClick);
             this.filesDataGridView.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.filesDataGridView_CellDoubleClick);
             this.filesDataGridView.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.filesDataGridView_CellEndEdit);
             this.filesDataGridView.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.filesDataGridView_CellMouseDown);
@@ -497,18 +498,22 @@
             // 
             this.minifyDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
             this.minifyDataGridViewCheckBoxColumn.DataPropertyName = "Minify";
+            this.minifyDataGridViewCheckBoxColumn.FalseValue = "false";
             this.minifyDataGridViewCheckBoxColumn.HeaderText = "Minify";
             this.minifyDataGridViewCheckBoxColumn.MinimumWidth = 40;
             this.minifyDataGridViewCheckBoxColumn.Name = "minifyDataGridViewCheckBoxColumn";
+            this.minifyDataGridViewCheckBoxColumn.TrueValue = "true";
             this.minifyDataGridViewCheckBoxColumn.Width = 40;
             // 
             // debugDataGridViewCheckBoxColumn
             // 
             this.debugDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
             this.debugDataGridViewCheckBoxColumn.DataPropertyName = "Debug";
+            this.debugDataGridViewCheckBoxColumn.FalseValue = "false";
             this.debugDataGridViewCheckBoxColumn.HeaderText = "Debug";
             this.debugDataGridViewCheckBoxColumn.MinimumWidth = 40;
             this.debugDataGridViewCheckBoxColumn.Name = "debugDataGridViewCheckBoxColumn";
+            this.debugDataGridViewCheckBoxColumn.TrueValue = "true";
             this.debugDataGridViewCheckBoxColumn.Width = 45;
             // 
             // mainForm

--- a/WinLess/Forms/mainForm.Designer.cs
+++ b/WinLess/Forms/mainForm.Designer.cs
@@ -50,10 +50,6 @@
             this.directoryFilesSplitContainer = new System.Windows.Forms.SplitContainer();
             this.foldersListBox = new System.Windows.Forms.ListBox();
             this.filesDataGridView = new System.Windows.Forms.DataGridView();
-            this.enabledDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.fullPathDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.outputPathDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.minifyDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.compileSelectedButton = new System.Windows.Forms.Button();
             this.addDirectoryButton = new System.Windows.Forms.Button();
             this.refreshDirectoryButton = new System.Windows.Forms.Button();
@@ -71,6 +67,11 @@
             this.compileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.notifyIconMenuExit = new System.Windows.Forms.ToolStripMenuItem();
             this.logoPictureBox = new System.Windows.Forms.PictureBox();
+            this.enabledDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.fullPathDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.outputPathDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.minifyDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.debugDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.directoryBindingSource)).BeginInit();
             this.menu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.fileBindingSource)).BeginInit();
@@ -144,7 +145,7 @@
             this.fileOpenFolderToolStripMenuItem,
             this.fileSelectOutputToolStripMenuItem});
             this.fileContextMenuStrip.Name = "fileContextMenuStrip";
-            this.fileContextMenuStrip.Size = new System.Drawing.Size(198, 92);
+            this.fileContextMenuStrip.Size = new System.Drawing.Size(198, 70);
             // 
             // openFiletoolStripMenuItem
             // 
@@ -253,7 +254,8 @@
             this.enabledDataGridViewTextBoxColumn,
             this.fullPathDataGridViewTextBoxColumn,
             this.outputPathDataGridViewTextBoxColumn,
-            this.minifyDataGridViewCheckBoxColumn});
+            this.minifyDataGridViewCheckBoxColumn,
+            this.debugDataGridViewCheckBoxColumn});
             this.filesDataGridView.DataSource = this.fileBindingSource;
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
@@ -273,45 +275,6 @@
             this.filesDataGridView.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.filesDataGridView_CellDoubleClick);
             this.filesDataGridView.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.filesDataGridView_CellEndEdit);
             this.filesDataGridView.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.filesDataGridView_CellMouseDown);
-            // 
-            // enabledDataGridViewTextBoxColumn
-            // 
-            this.enabledDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.enabledDataGridViewTextBoxColumn.DataPropertyName = "Enabled";
-            this.enabledDataGridViewTextBoxColumn.HeaderText = "";
-            this.enabledDataGridViewTextBoxColumn.MinimumWidth = 30;
-            this.enabledDataGridViewTextBoxColumn.Name = "enabledDataGridViewTextBoxColumn";
-            this.enabledDataGridViewTextBoxColumn.Width = 30;
-            // 
-            // fullPathDataGridViewTextBoxColumn
-            // 
-            this.fullPathDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.fullPathDataGridViewTextBoxColumn.ContextMenuStrip = this.fileContextMenuStrip;
-            this.fullPathDataGridViewTextBoxColumn.DataPropertyName = "RelativePath";
-            this.fullPathDataGridViewTextBoxColumn.HeaderText = "File";
-            this.fullPathDataGridViewTextBoxColumn.MinimumWidth = 150;
-            this.fullPathDataGridViewTextBoxColumn.Name = "fullPathDataGridViewTextBoxColumn";
-            this.fullPathDataGridViewTextBoxColumn.ReadOnly = true;
-            this.fullPathDataGridViewTextBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            // 
-            // outputPathDataGridViewTextBoxColumn
-            // 
-            this.outputPathDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.outputPathDataGridViewTextBoxColumn.ContextMenuStrip = this.fileContextMenuStrip;
-            this.outputPathDataGridViewTextBoxColumn.DataPropertyName = "RelativeOutputPath";
-            this.outputPathDataGridViewTextBoxColumn.HeaderText = "Output file";
-            this.outputPathDataGridViewTextBoxColumn.MinimumWidth = 150;
-            this.outputPathDataGridViewTextBoxColumn.Name = "outputPathDataGridViewTextBoxColumn";
-            this.outputPathDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // minifyDataGridViewCheckBoxColumn
-            // 
-            this.minifyDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.minifyDataGridViewCheckBoxColumn.DataPropertyName = "Minify";
-            this.minifyDataGridViewCheckBoxColumn.HeaderText = "Minify";
-            this.minifyDataGridViewCheckBoxColumn.MinimumWidth = 40;
-            this.minifyDataGridViewCheckBoxColumn.Name = "minifyDataGridViewCheckBoxColumn";
-            this.minifyDataGridViewCheckBoxColumn.Width = 40;
             // 
             // compileSelectedButton
             // 
@@ -500,6 +463,54 @@
             this.logoPictureBox.TabIndex = 9;
             this.logoPictureBox.TabStop = false;
             // 
+            // enabledDataGridViewTextBoxColumn
+            // 
+            this.enabledDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            this.enabledDataGridViewTextBoxColumn.DataPropertyName = "Enabled";
+            this.enabledDataGridViewTextBoxColumn.HeaderText = "";
+            this.enabledDataGridViewTextBoxColumn.MinimumWidth = 30;
+            this.enabledDataGridViewTextBoxColumn.Name = "enabledDataGridViewTextBoxColumn";
+            this.enabledDataGridViewTextBoxColumn.Width = 30;
+            // 
+            // fullPathDataGridViewTextBoxColumn
+            // 
+            this.fullPathDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.fullPathDataGridViewTextBoxColumn.ContextMenuStrip = this.fileContextMenuStrip;
+            this.fullPathDataGridViewTextBoxColumn.DataPropertyName = "RelativePath";
+            this.fullPathDataGridViewTextBoxColumn.HeaderText = "File";
+            this.fullPathDataGridViewTextBoxColumn.MinimumWidth = 150;
+            this.fullPathDataGridViewTextBoxColumn.Name = "fullPathDataGridViewTextBoxColumn";
+            this.fullPathDataGridViewTextBoxColumn.ReadOnly = true;
+            this.fullPathDataGridViewTextBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            // 
+            // outputPathDataGridViewTextBoxColumn
+            // 
+            this.outputPathDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.outputPathDataGridViewTextBoxColumn.ContextMenuStrip = this.fileContextMenuStrip;
+            this.outputPathDataGridViewTextBoxColumn.DataPropertyName = "RelativeOutputPath";
+            this.outputPathDataGridViewTextBoxColumn.HeaderText = "Output file";
+            this.outputPathDataGridViewTextBoxColumn.MinimumWidth = 150;
+            this.outputPathDataGridViewTextBoxColumn.Name = "outputPathDataGridViewTextBoxColumn";
+            this.outputPathDataGridViewTextBoxColumn.ReadOnly = true;
+            // 
+            // minifyDataGridViewCheckBoxColumn
+            // 
+            this.minifyDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.minifyDataGridViewCheckBoxColumn.DataPropertyName = "Minify";
+            this.minifyDataGridViewCheckBoxColumn.HeaderText = "Minify";
+            this.minifyDataGridViewCheckBoxColumn.MinimumWidth = 40;
+            this.minifyDataGridViewCheckBoxColumn.Name = "minifyDataGridViewCheckBoxColumn";
+            this.minifyDataGridViewCheckBoxColumn.Width = 40;
+            // 
+            // debugDataGridViewCheckBoxColumn
+            // 
+            this.debugDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.debugDataGridViewCheckBoxColumn.DataPropertyName = "Debug";
+            this.debugDataGridViewCheckBoxColumn.HeaderText = "Debug";
+            this.debugDataGridViewCheckBoxColumn.MinimumWidth = 40;
+            this.debugDataGridViewCheckBoxColumn.Name = "debugDataGridViewCheckBoxColumn";
+            this.debugDataGridViewCheckBoxColumn.Width = 45;
+            // 
             // mainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -567,15 +578,16 @@
         private System.Windows.Forms.SplitContainer directoryFilesSplitContainer;
         private System.Windows.Forms.ListBox foldersListBox;
         private System.Windows.Forms.DataGridView filesDataGridView;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn enabledDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn fullPathDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn outputPathDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn minifyDataGridViewCheckBoxColumn;
         private System.Windows.Forms.Button compileSelectedButton;
         private System.Windows.Forms.Button addDirectoryButton;
         private System.Windows.Forms.Button refreshDirectoryButton;
         private System.Windows.Forms.Button removeDirectoryButton;
         private System.Windows.Forms.ToolStripMenuItem compileToolStripMenuItem;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn enabledDataGridViewTextBoxColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn fullPathDataGridViewTextBoxColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn outputPathDataGridViewTextBoxColumn;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn minifyDataGridViewCheckBoxColumn;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn debugDataGridViewCheckBoxColumn;
     }
 }
 

--- a/WinLess/Forms/mainForm.cs
+++ b/WinLess/Forms/mainForm.cs
@@ -92,6 +92,7 @@ namespace WinLess
                     foreach (Models.File file in directory.Files)
                     {
                         file.Minify = args.Minify;
+                        file.Debug = args.Debug;
                         if (args.InitialCompile)
                         {
                             file.Compile();
@@ -523,7 +524,7 @@ namespace WinLess
             {
                 if (file.Enabled)
                 {
-                    LessCompiler.Compile(file.FullPath, file.OutputPath, file.Minify);
+                    LessCompiler.Compile(file.FullPath, file.OutputPath, file.Minify, file.Debug);
                 }
             }
         }

--- a/WinLess/Forms/mainForm.cs
+++ b/WinLess/Forms/mainForm.cs
@@ -530,5 +530,54 @@ namespace WinLess
         }
 
         #endregion
+
+        private void filesDataGridView_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            DataGridView dgv = (DataGridView)sender;
+            bool minifyed, debug;
+            //DataGridViewCheckBoxCell currentCell;
+
+            minifyed = (bool)dgv.CurrentRow.Cells[3].EditedFormattedValue;
+            debug = (bool)dgv.CurrentRow.Cells[4].EditedFormattedValue;
+
+            if (dgv.CurrentCell.ColumnIndex == 3 || dgv.CurrentCell.ColumnIndex == 4)
+            {
+                if (minifyed && debug)
+                {
+                    MessageBox.Show("You can´t minify and add debug.", "Information", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    dgv.CurrentRow.Cells[4].Value = false;
+                    dgv.CurrentRow.Cells[3].Value = false;
+                    return;
+                }
+                
+                /*currentCell = (DataGridViewCheckBoxCell)dgv.CurrentCell;
+                switch (currentCell.ColumnIndex)
+                {
+                    case 3:
+                        //Minfy
+                        if ((bool)dgv.CurrentCell.EditedFormattedValue == true)
+                        {
+                            if (minifyed)
+                            {
+                                MessageBox.Show("You can´t minify when debug is checked.", "Information", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                dgv.CurrentRow.Cells[4].Value = false;
+                                dgv.CurrentRow.Cells[3].Value = false;
+                                return;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+                        break;
+                    case 4:
+                           dgv.CurrentRow.Cells[4].Value = false;
+                           dgv.CurrentRow.Cells[3].Value = false;
+                        //debug
+                        break;
+                } */
+            }
+            
+        }
     }
 }

--- a/WinLess/Forms/mainForm.resx
+++ b/WinLess/Forms/mainForm.resx
@@ -129,6 +129,9 @@
   <metadata name="fileContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>835, 17</value>
   </metadata>
+  <metadata name="debugDataGridViewCheckBoxColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="fileDataGridViewTextBoxColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/WinLess/Forms/settingsForm.Designer.cs
+++ b/WinLess/Forms/settingsForm.Designer.cs
@@ -32,20 +32,21 @@
             this.cancelButton = new System.Windows.Forms.Button();
             this.okButton = new System.Windows.Forms.Button();
             this.generalGroupBox = new System.Windows.Forms.GroupBox();
+            this.checkForLessUpdatesCheckbox = new System.Windows.Forms.CheckBox();
             this.startMinimizedCheckBox = new System.Windows.Forms.CheckBox();
             this.startWithWindowsCheckBox = new System.Windows.Forms.CheckBox();
             this.compilingGroupBox = new System.Windows.Forms.GroupBox();
+            this.AddDebuggInfoCheckBox = new System.Windows.Forms.CheckBox();
             this.showSuccessMessagesCheckbox = new System.Windows.Forms.CheckBox();
             this.compileOnSaveCheckBox = new System.Windows.Forms.CheckBox();
             this.defaultMinifyCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkForLessUpdatesCheckbox = new System.Windows.Forms.CheckBox();
             this.generalGroupBox.SuspendLayout();
             this.compilingGroupBox.SuspendLayout();
             this.SuspendLayout();
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(197, 233);
+            this.cancelButton.Location = new System.Drawing.Point(197, 275);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 0;
@@ -55,7 +56,7 @@
             // 
             // okButton
             // 
-            this.okButton.Location = new System.Drawing.Point(116, 233);
+            this.okButton.Location = new System.Drawing.Point(116, 275);
             this.okButton.Name = "okButton";
             this.okButton.Size = new System.Drawing.Size(75, 23);
             this.okButton.TabIndex = 1;
@@ -74,6 +75,16 @@
             this.generalGroupBox.TabIndex = 2;
             this.generalGroupBox.TabStop = false;
             this.generalGroupBox.Text = "General";
+            // 
+            // checkForLessUpdatesCheckbox
+            // 
+            this.checkForLessUpdatesCheckbox.AutoSize = true;
+            this.checkForLessUpdatesCheckbox.Location = new System.Drawing.Point(7, 67);
+            this.checkForLessUpdatesCheckbox.Name = "checkForLessUpdatesCheckbox";
+            this.checkForLessUpdatesCheckbox.Size = new System.Drawing.Size(208, 17);
+            this.checkForLessUpdatesCheckbox.TabIndex = 2;
+            this.checkForLessUpdatesCheckbox.Text = "Automatically check for less.js updates";
+            this.checkForLessUpdatesCheckbox.UseVisualStyleBackColor = true;
             // 
             // startMinimizedCheckBox
             // 
@@ -97,15 +108,26 @@
             // 
             // compilingGroupBox
             // 
+            this.compilingGroupBox.Controls.Add(this.AddDebuggInfoCheckBox);
             this.compilingGroupBox.Controls.Add(this.showSuccessMessagesCheckbox);
             this.compilingGroupBox.Controls.Add(this.compileOnSaveCheckBox);
             this.compilingGroupBox.Controls.Add(this.defaultMinifyCheckBox);
             this.compilingGroupBox.Location = new System.Drawing.Point(13, 127);
             this.compilingGroupBox.Name = "compilingGroupBox";
-            this.compilingGroupBox.Size = new System.Drawing.Size(259, 100);
+            this.compilingGroupBox.Size = new System.Drawing.Size(259, 122);
             this.compilingGroupBox.TabIndex = 3;
             this.compilingGroupBox.TabStop = false;
             this.compilingGroupBox.Text = "Compiling";
+            // 
+            // AddDebuggInfoCheckBox
+            // 
+            this.AddDebuggInfoCheckBox.AutoSize = true;
+            this.AddDebuggInfoCheckBox.Location = new System.Drawing.Point(6, 91);
+            this.AddDebuggInfoCheckBox.Name = "AddDebuggInfoCheckBox";
+            this.AddDebuggInfoCheckBox.Size = new System.Drawing.Size(147, 17);
+            this.AddDebuggInfoCheckBox.TabIndex = 3;
+            this.AddDebuggInfoCheckBox.Text = "Add debug info as default";
+            this.AddDebuggInfoCheckBox.UseVisualStyleBackColor = true;
             // 
             // showSuccessMessagesCheckbox
             // 
@@ -137,21 +159,11 @@
             this.defaultMinifyCheckBox.Text = "Minify by default";
             this.defaultMinifyCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkForLessUpdatesCheckbox
-            // 
-            this.checkForLessUpdatesCheckbox.AutoSize = true;
-            this.checkForLessUpdatesCheckbox.Location = new System.Drawing.Point(7, 67);
-            this.checkForLessUpdatesCheckbox.Name = "checkForLessUpdatesCheckbox";
-            this.checkForLessUpdatesCheckbox.Size = new System.Drawing.Size(208, 17);
-            this.checkForLessUpdatesCheckbox.TabIndex = 2;
-            this.checkForLessUpdatesCheckbox.Text = "Automatically check for less.js updates";
-            this.checkForLessUpdatesCheckbox.UseVisualStyleBackColor = true;
-            // 
             // settingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(289, 268);
+            this.ClientSize = new System.Drawing.Size(289, 325);
             this.Controls.Add(this.compilingGroupBox);
             this.Controls.Add(this.generalGroupBox);
             this.Controls.Add(this.okButton);
@@ -179,5 +191,6 @@
         private System.Windows.Forms.CheckBox compileOnSaveCheckBox;
         private System.Windows.Forms.CheckBox showSuccessMessagesCheckbox;
         private System.Windows.Forms.CheckBox checkForLessUpdatesCheckbox;
+        private System.Windows.Forms.CheckBox AddDebuggInfoCheckBox;
     }
 }

--- a/WinLess/Forms/settingsForm.Designer.cs
+++ b/WinLess/Forms/settingsForm.Designer.cs
@@ -128,6 +128,7 @@
             this.AddDebuggInfoCheckBox.TabIndex = 3;
             this.AddDebuggInfoCheckBox.Text = "Add debug info as default";
             this.AddDebuggInfoCheckBox.UseVisualStyleBackColor = true;
+            this.AddDebuggInfoCheckBox.CheckedChanged += new System.EventHandler(this.AddDebuggInfoCheckBox_CheckedChanged);
             // 
             // showSuccessMessagesCheckbox
             // 
@@ -158,6 +159,7 @@
             this.defaultMinifyCheckBox.TabIndex = 0;
             this.defaultMinifyCheckBox.Text = "Minify by default";
             this.defaultMinifyCheckBox.UseVisualStyleBackColor = true;
+            this.defaultMinifyCheckBox.CheckedChanged += new System.EventHandler(this.defaultMinifyCheckBox_CheckedChanged);
             // 
             // settingsForm
             // 

--- a/WinLess/Forms/settingsForm.cs
+++ b/WinLess/Forms/settingsForm.cs
@@ -24,6 +24,7 @@ namespace WinLess
             defaultMinifyCheckBox.Checked = Program.Settings.DefaultMinify;
             compileOnSaveCheckBox.Checked = Program.Settings.CompileOnSave;
             showSuccessMessagesCheckbox.Checked = Program.Settings.ShowSuccessMessages;
+            AddDebuggInfoCheckBox.Checked = Program.Settings.DefaultDebugInfo;
         }
 
         private void saveSettings()
@@ -34,6 +35,7 @@ namespace WinLess
             Program.Settings.DefaultMinify = defaultMinifyCheckBox.Checked;
             Program.Settings.CompileOnSave = compileOnSaveCheckBox.Checked;
             Program.Settings.ShowSuccessMessages = showSuccessMessagesCheckbox.Checked;
+            Program.Settings.DefaultDebugInfo = AddDebuggInfoCheckBox.Checked;
             Program.Settings.SaveSettings();
         }
 
@@ -46,6 +48,6 @@ namespace WinLess
         {
             saveSettings();
             this.Close();
-        }
+        }      
     }
 }

--- a/WinLess/Forms/settingsForm.cs
+++ b/WinLess/Forms/settingsForm.cs
@@ -48,6 +48,26 @@ namespace WinLess
         {
             saveSettings();
             this.Close();
+        }
+
+        private void AddDebuggInfoCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (defaultMinifyCheckBox.Checked && AddDebuggInfoCheckBox.Checked)
+            {
+                MessageBox.Show("You can´t add debug info when minifying. Please uncheck '" + defaultMinifyCheckBox.Text + "'", "Information", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                AddDebuggInfoCheckBox.Checked = false;
+                return;
+            }
+        }
+
+        private void defaultMinifyCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (defaultMinifyCheckBox.Checked && AddDebuggInfoCheckBox.Checked)
+            {
+                MessageBox.Show("You can´t minifying and add debug info. Please uncheck '" + AddDebuggInfoCheckBox.Text + "'", "Information", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                AddDebuggInfoCheckBox.Checked = false;
+                return;
+            }
         }      
     }
 }

--- a/WinLess/LessCompiler.cs
+++ b/WinLess/LessCompiler.cs
@@ -6,16 +6,17 @@ using System.IO;
 using WinLess.Models;
 using WinLess.Helpers;
 using System.Text.RegularExpressions;
+using System.Web;
 
 namespace WinLess
 {
     public static class LessCompiler
     {        
-        public static void Compile(string lessFile, string cssFile, bool minify)
+        public static void Compile(string lessFile, string cssFile, bool minify, bool addDebugInfo)
         {
             try
             {
-                CompileCommandResult compileResult = ExecuteCompileCommand(lessFile, cssFile, minify);
+                CompileCommandResult compileResult = ExecuteCompileCommand(lessFile, cssFile, minify, addDebugInfo);
                 mainForm.ActiveOrInActiveMainForm.AddCompileResult(compileResult);
             }
             catch (Exception e)
@@ -76,22 +77,27 @@ namespace WinLess
             return ExecuteCommand(fileName, arguments);
         }
 
-        private static CompileCommandResult ExecuteCompileCommand(string lessFile, string cssFile, bool minify)
-        { 
-            string arguments = CreateCompileArguments(lessFile, cssFile, minify);
+        private static CompileCommandResult ExecuteCompileCommand(string lessFile, string cssFile, bool minify, bool addDebugInfo)
+        {
+            string arguments = CreateCompileArguments(lessFile, cssFile, minify, addDebugInfo);
 
             CompileCommandResult result = new CompileCommandResult(ExecuteLessCommand(arguments));
             result.FullPath = lessFile;
-
+           
             return result;
         }
 
-        private static string CreateCompileArguments(string lessFile, string cssFile, bool minify)
+        private static string CreateCompileArguments(string lessFile, string cssFile, bool minify, bool addDebugInfo)
         {
         string arguments = string.Format("\"{0}\" \"{1}\" --no-color", lessFile, cssFile);
             if (minify)
             {
                 arguments = string.Format("{0} --yui-compress", arguments);
+            }
+
+            if (addDebugInfo)
+            {
+                arguments = string.Format("{0} --line-numbers=all", arguments);
             }
 
             return arguments;
@@ -140,5 +146,6 @@ namespace WinLess
 
             return result;
         }
+       
     }
 }

--- a/WinLess/Models/CommandArguments.cs
+++ b/WinLess/Models/CommandArguments.cs
@@ -15,6 +15,7 @@ namespace WinLess.Models
             Minify = false;
             InitialCompile = false;
             ClearDirectories = false;
+            Debug = false;
 
             if (HasArguments)
             {
@@ -45,6 +46,11 @@ namespace WinLess.Models
                         "h|help",
                         "Show this message and exit",
                         v=> ShowHelp = v != null
+                    },
+                    {
+                        "debug",
+                         "Add the 'debug' flag to add debug info",
+                         v=> Debug = v != null
                     }
                 };
 
@@ -90,6 +96,7 @@ namespace WinLess.Models
         public bool Minify { get; set; }
         public bool InitialCompile { get; set; }
         public bool ClearDirectories { get; set; }
+        public bool Debug { get; set; }
 
         #endregion
 

--- a/WinLess/Models/File.cs
+++ b/WinLess/Models/File.cs
@@ -22,6 +22,7 @@ namespace WinLess.Models
             this.FullPath = fullPath;
             this.ProjectDirectoryPath = directory.FullPath;
             this.Minify = Program.Settings.DefaultMinify;
+            this.Debug = Program.Settings.DefaultDebugInfo;
             this.Enabled = true;
             this.OutputPath = GetInitialOutputPath();
             this.ParentFiles = new List<File>();
@@ -88,6 +89,12 @@ namespace WinLess.Models
             get;
             set;
         }
+        public bool Debug
+        {
+            get;
+            set;
+        }
+
 
         [XmlIgnore]
         public List<File> ParentFiles
@@ -116,7 +123,7 @@ namespace WinLess.Models
         {
             if (this.Enabled)
             {
-                LessCompiler.Compile(this.FullPath, this.OutputPath, this.Minify);
+                LessCompiler.Compile(this.FullPath, this.OutputPath, this.Minify, this.Debug);
             }
             if (compileParentFiles)
             {

--- a/WinLess/Properties/AssemblyInfo.cs
+++ b/WinLess/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyFileVersion("1.8.0.0")]
+[assembly: AssemblyVersion("1.8.1.0")]
+[assembly: AssemblyFileVersion("1.8.1.0")]

--- a/WinLess/Settings.cs
+++ b/WinLess/Settings.cs
@@ -28,6 +28,7 @@ namespace WinLess
         public bool ShowSuccessMessages { get; set; }
         public bool StartMinified { get; set; }
         public bool CheckForLessUpdates { get; set; }
+        public bool DefaultDebugInfo { get; set; }
 
         private bool startWithWindows;
         public bool StartWithWindows


### PR DESCRIPTION
Added support to add debug-info in css.

Adding --line-numbers=all to the Less compiler. 

More information : http://q42.nl/blog/post/35203391115/debug-sass-and-less-in-webkit-inspector-and-save-css-cha
